### PR TITLE
Publicly document existing processes and requirements to become a maintainer

### DIFF
--- a/HOW_TO_BECOME_A_MAINTAINER.md
+++ b/HOW_TO_BECOME_A_MAINTAINER.md
@@ -1,0 +1,50 @@
+# How to Become a Maintainer
+
+## Types of Maintainers
+
+### SME (Subject Matter Expert)
+
+#### Pre Conditions
+To become an SME maintainer you must meet one of the following conditions:
+1. Created a repo, wants to migrated it to the Community but will continue on as a contributor
+1. Has made significant contributions to a particular repo
+
+The following is required:
+1. Have MFA (Multi Factor Authentication) enabled on your Github account
+
+#### Process
+
+1. Open an [issue](https://github.com/sensu-plugins/community/issues/new) indicating that you would like to either transfer your repository into the organization or indicate which repo(s) you wish to maintain as an SME.
+
+### Maintainer
+
+Most maintainers are targetted at maintainting a specific set of repositiories based on language, function (plugin vs extension), Documentation, etc
+
+#### Pre Conditions
+
+1. Shown consistent and quality contributions to multiple repositories in the Sensu ecosystem.
+1. MFA enabled on your Github account
+1. Have setup PGP with github so you can sign commits to guarantee that your commits are your own
+
+
+#### Process
+
+1. Open an [issue](https://github.com/sensu-plugins/community/issues/new) indicating that you would like to become a maintainer for one or more areas such as `ruby_plugins`, `ruby_extensions`, `windows_plugins`, `python_plugins`, etc For a full list areas that are maintained look [here](https://github.com/sensu-plugins/community#maintained-areas)
+1. Endorsed by two or more active maintainers with no vetos against them
+1. Have acknowledged that they have read and will abide by the terms outlined in the [Code of Conduct](https://sensu.io/conduct)
+1. Will be invited to the organization, teams, slack channels, etc as outlined via internal maintainer processes.
+
+### Org Maintainer
+
+An org maintainer is not scoped to specific projects (even if they mostly focus on an area), they provide OSS mentorship to other maintainers, manage permissions + credentials, set organization wide policies, etc.
+
+#### Pre conditions
+
+1. Meet all conditions of being a maintainer
+1. Kick ass on a regular basis
+1. Be endorsed by two current Org Maintainers
+
+#### Process
+
+1. This is really an internal process, once becoming a maintainer reach out to an existing org maintainer to start informal internal discussions.
+


### PR DESCRIPTION
This is largely based on existing processes that are documentated in private repositories. Internal documentation will be updated based on the process which is made publicly accessible.

Signed-off-by: Ben Abrams <me@benabrams.it>